### PR TITLE
fix: SeedCard and Footer responsive layout

### DIFF
--- a/app/components/SeedCard/SeedCard.tsx
+++ b/app/components/SeedCard/SeedCard.tsx
@@ -58,7 +58,7 @@ export default function SeedCard({
           </span>
         </div>
         <div className="flex gap-2">
-          {userInfo?.level && userInfo?.level > 2 && (
+          {!!userInfo?.level && userInfo?.level > 2 && (
             <SVGIcon
               name="delete"
               onClick={handleDeleteSeed}
@@ -136,7 +136,7 @@ export default function SeedCard({
           />
           <span>{seed.raider}</span>
         </div>
-        <div className="text-sm">
+        <div className="text-sm max-sm:w-16">
           {new Date(seed.date_created).toLocaleString("zh-CN")}
         </div>
         <div className="flex gap-2">

--- a/app/modules/Footer/Footer.tsx
+++ b/app/modules/Footer/Footer.tsx
@@ -14,6 +14,7 @@ const StyledFooterInner = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  gap: 4rem;
 `;
 
 const links = [
@@ -30,7 +31,7 @@ export function Footer() {
           <Link
             to={link.to}
             key={link.text}
-            className="font-bold text-lg me-24 last-of-type:me-0 hover:text-ak-blue"
+            className="font-bold text-lg hover:text-ak-blue"
             onClick={(evt) => {
               if (link.targetModal) {
                 evt.preventDefault();

--- a/app/modules/PageNav/PageNavbar.tsx
+++ b/app/modules/PageNav/PageNavbar.tsx
@@ -9,7 +9,7 @@ const StyledPageNavbar = styled.div`
   align-items: center;
   height: 6rem;
   font-size: 1.5rem;
-  overflow-y: auto;
+  overflow-y: hidden;
   border-color: rgba(255, 255, 255, 0.2);
 `;
 


### PR DESCRIPTION
### Notes
Fixed SeedCard and Footer responsive layout, tested with iPhone 12 and free responsive dimensions. 

### Screenshots
| Before      | After |
| ----------- | ----------- |
| <img width="297" alt="Screenshot 2025-02-02 at 3 51 39 PM" src="https://github.com/user-attachments/assets/f6538d32-b9e4-41b5-b776-3dd33e53de0d" /> | <img width="296" alt="Screenshot 2025-02-02 at 3 51 53 PM" src="https://github.com/user-attachments/assets/a1dfcd7e-890c-46f1-9086-919babfb1516" />       |