### PR TITLE
fix: modals did not fit window size and cannot scroll

### DIFF
--- a/app/components/Modal/InclusionPrincipleModal.tsx
+++ b/app/components/Modal/InclusionPrincipleModal.tsx
@@ -2,15 +2,12 @@ import { useAppDataStore } from "~/stores/appDataStore";
 import Loading from "~/components/Loading";
 import Markdown from "react-markdown";
 import {
-  Modal,
   ModalBody,
-  ModalContent,
   ModalHeader,
   useDisclosure,
 } from "@heroui/react";
 import { ModalFooter } from "@heroui/modal";
-import { SVGIcon } from "~/components/SVGIcon/SVGIcon";
-import React from "react";
+import ModalTemplate from "~/components/Modal";
 
 export default function InclusionPrincipleModal({ id }: { id: string }) {
   const { inclusionPrinciple } = useAppDataStore();
@@ -18,39 +15,25 @@ export default function InclusionPrincipleModal({ id }: { id: string }) {
   return (
     <>
       <button className="hidden" id={id} onClick={onOpen} />
-      <Modal
+      <ModalTemplate
         isOpen={isOpen}
         onClose={onClose}
-        placement="top-center"
         radius="none"
-        size="full"
-        scrollBehavior="inside"
-        classNames={{
-          base: "my-20",
-          backdrop: "backdrop-blur-sm",
-          closeButton: "top-6 end-6 bg-black-gray",
-        }}
         backdrop="blur"
-        closeButton={
-          <button style={{ zIndex: 1000 }}>
-            <SVGIcon name="modal-close" width="0.7rem" height="0.7rem" />
-          </button>
-        }
+        size="3xl"
       >
-        <ModalContent>
-          {inclusionPrinciple ? (
-            <>
-              <ModalHeader>收录原则</ModalHeader>
-              <ModalBody>
-                <Markdown>{inclusionPrinciple}</Markdown>
-              </ModalBody>
-              <ModalFooter />
-            </>
-          ) : (
-            <Loading />
-          )}
-        </ModalContent>
-      </Modal>
+        {inclusionPrinciple ? (
+          <>
+            <ModalHeader>收录原则</ModalHeader>
+            <ModalBody>
+              <Markdown>{inclusionPrinciple}</Markdown>
+            </ModalBody>
+            <ModalFooter />
+          </>
+        ) : (
+          <Loading />
+        )}
+      </ModalTemplate>
     </>
   );
 }

--- a/app/components/Modal/index.tsx
+++ b/app/components/Modal/index.tsx
@@ -50,7 +50,7 @@ export default function ModalTemplate({
         placement="top-center"
         radius="none"
         classNames={{
-          base: "my-20",
+          base: "my-20 overflow-y-auto",
           backdrop: "backdrop-blur-sm",
           closeButton: "top-6 end-6 bg-black-gray",
         }}
@@ -61,6 +61,7 @@ export default function ModalTemplate({
           </button>
         }
         {...props}
+        scrollBehavior="inside"
       >
         <ModalContent>
           <StyledModalContent>{children}</StyledModalContent>


### PR DESCRIPTION
### Notes
Fixes #7. Fix modals did not fit window size and cannot scroll.


### Screenshots
#### 收录原则
| Before      | After |
| ----------- | ----------- |
| <img width="1512" alt="Screenshot 2025-02-03 at 4 06 12 PM" src="https://github.com/user-attachments/assets/049034a7-545e-45f1-a3ab-d0d883e8f7f5" />      | <img width="1512" alt="Screenshot 2025-02-03 at 4 05 58 PM" src="https://github.com/user-attachments/assets/66ea2e5b-5e96-4a28-9086-eed627c14367" />       |

#### 投稿种子
| Before      | After |
| ----------- | ----------- |
| <img width="1512" alt="Screenshot 2025-02-03 at 4 06 41 PM" src="https://github.com/user-attachments/assets/a1dfca1d-5fa0-453a-a63c-663978152953" /> | <img width="1512" alt="Screenshot 2025-02-03 at 4 06 28 PM" src="https://github.com/user-attachments/assets/aa580d73-6526-4e71-9824-f82ddd11c1ae" />      |



