### PR TITLE
fix: #9 探索者的银凇止境banner description contrast problem

### DIFF
--- a/app/modules/RelicFree/Selector/SelectorBanner.tsx
+++ b/app/modules/RelicFree/Selector/SelectorBanner.tsx
@@ -47,10 +47,10 @@ const LeftMask = styled.div`
   height: 100%;
   width: 100%;
   background: linear-gradient(
-    90deg,
+    45deg,
     #000 0%,
     rgba(0, 0, 0, 0.75) 10%,
-    rgba(0, 0, 0, 0) 30%,
+    rgba(0, 0, 0, 0) 90%,
     transparent
   );
   z-index: -1;


### PR DESCRIPTION
Fixed #9 探索者的银凇止境banner description contrast problem.

| Before      | After |
| ----------- | ----------- |
| <img width="1178" alt="Screenshot 2025-02-05 at 10 34 05 AM" src="https://github.com/user-attachments/assets/27245e99-f42e-4b2a-adfb-e4387408f604" />      | <img width="1177" alt="Screenshot 2025-02-05 at 10 34 57 AM" src="https://github.com/user-attachments/assets/80f84aba-6692-4657-92b3-f0a89bcbc1e8" />       |


