### PR TITLE
fix: 切换肉鸽时清除层数选择；修复关卡页面紧急人数颜色

### DIFF
--- a/app/components/RecordCard/RecordCard.tsx
+++ b/app/components/RecordCard/RecordCard.tsx
@@ -215,7 +215,7 @@ export default function RecordCard({
                 "text-[2.5rem] absolute left-16 top-1/2 -translate-y-1/2 " +
                 (record.type === "normal"
                   ? "text-ak-blue"
-                  : record.type === "challenge"
+                  : record.type === "elite"
                     ? "text-ak-red"
                     : "text-ak-purple")
               }

--- a/app/modules/RelicFree/Selector/SelectorBanner.tsx
+++ b/app/modules/RelicFree/Selector/SelectorBanner.tsx
@@ -103,6 +103,7 @@ export default function SelectorBanner({
                 role="button"
                 onClick={() => {
                   searchParams.set("topicId", topic.id);
+                  if (topic.id !== currentTopic.id) searchParams.delete("zoneId");
                   setSearchParams(searchParams, {
                     preventScrollReset: true,
                   });


### PR DESCRIPTION
1. 切换肉鸽时清除层数选择。改动前`/relic-free`页面每次切换肉鸽时，url里的`zoneId`没有清除会导致层数filter保留。

2. 修复关卡页面紧急人数颜色

| Before      | After |
| ----------- | ----------- |
|  <img width="1024" alt="Screenshot 2025-03-05 at 1 28 30 PM" src="https://github.com/user-attachments/assets/4b52f1ab-533e-41e8-8c3b-dceb547967ac" />   |   <img width="1026" alt="Screenshot 2025-03-05 at 1 27 57 PM" src="https://github.com/user-attachments/assets/470850c1-c921-4ff7-ad61-de1bea55a74f" />      |