### PR TITLE
fix:界园科技树默认加成为1.2，家常小炒正常生效

### DIFF
--- a/app/modules/Tool/DamageCalculator/calculator/blackboard.ts
+++ b/app/modules/Tool/DamageCalculator/calculator/blackboard.ts
@@ -788,8 +788,13 @@ export const commonCharRelicBlackboard: RelicBlackboard = {
 
     // 是否加算
     const is_add = buff.key.includes("_attribute_add");
-    /** 如果buff不含层数效果，忽视用户填写的层数 */
-    const layer = relicHasLayer(relic) ? relic.layer : 1;
+
+    // /** 如果buff不含层数效果，忽视用户填写的层数 */
+    // const layer = relicHasLayer(relic) ? relic.layer : 1;
+
+    /** 如果buff的key以layer_开头，说明受层数影响，否则固定为1层 */
+    const layer = buff.key.startsWith("layer_") ? relic.layer : 1;
+
     // 是否局内
     const inGame = inGameRelicNames.includes(relic.name) || ["buff", "ability"].some((kw) => buff.key.includes(kw));
 

--- a/app/modules/Tool/DamageCalculator/calculator/blackboard.ts
+++ b/app/modules/Tool/DamageCalculator/calculator/blackboard.ts
@@ -609,6 +609,47 @@ registerRelicBlackboard("rogue_5_left_or_right_most_tile_col[attri_up]", {
   },
 });
 
+/** 奔兽战车 - 部署费用上限+30，部署费用达到99以及以上时，所有干员局内生命+50%，阻挡数+1 */
+registerRelicBlackboard("attri_up_filter_level_cost", {
+  isActive(input) {
+    const { buff, relics } = input;
+    const costThreshold = getByKey(buff.blackboard, "cost");
+
+    // 计算费用条件
+    if (costThreshold) {
+      let maxCostBonus = 99;
+      for (const relic of relics) {
+        for (const relicBuff of relic.buffs) {
+          if (relicBuff.key === "level_max_cost_add") {
+            const maxCost = getByKey(relicBuff.blackboard, "max_cost");
+            if (maxCost) {
+              maxCostBonus += maxCost.value;
+            }
+          }
+        }
+      }
+
+      return maxCostBonus >= costThreshold.value;
+    }
+
+    return true;
+  },
+  apply(input): void {
+    const { context, buff, relic } = input;
+    const max_hp = getByKey(buff.blackboard, "max_hp");
+    const block_cnt = getByKey(buff.blackboard, "block_cnt");
+
+    // 生命值 - 局内乘算
+    if (max_hp) {
+      context.in_game_buff_mul.max_hp.addChild(new NumericLiteralNode(max_hp.value, relic.name));
+    }
+    // 阻挡数 - 局内加算
+    if (block_cnt) {
+      context.in_game_buff_add.block_cnt.addChild(new NumericLiteralNode(block_cnt.value, relic.name));
+    }
+  },
+});
+
 /** 通用敌人藏品黑板 */
 export const commonEnemyRelicBlackboard = {
   isActive({ buff, enemyData, relic, stageData }: EnemyRelicBlackboardInput) {

--- a/app/modules/Tool/DamageCalculator/calculator/blackboard.ts
+++ b/app/modules/Tool/DamageCalculator/calculator/blackboard.ts
@@ -817,12 +817,25 @@ export const commonCharRelicBlackboard: RelicBlackboard = {
       is_invalid = false;
     }
     /** 防御力 */
+    // if (def) {
+    //   const node = new NumericLiteralNode(def.value * layer, relic.name, { relic, buff });
+    //   if (is_add) {
+    //     context.relic_rune_add.def.addChild(node);
+    //   } else {
+    //     context.relic_rune_mul.def.addChild(node);
+    //   }
+    //   is_invalid = false;
+    // }
     if (def) {
-      const node = new NumericLiteralNode(def.value * layer, relic.name, { relic, buff });
-      if (is_add) {
-        context.relic_rune_add.def.addChild(node);
+      if (inGame) {
+        context.in_game_buff_mul.def.addChild(new NumericLiteralNode(def.value * relic.layer, relic.name));
       } else {
-        context.relic_rune_mul.def.addChild(node);
+        const node = new NumericLiteralNode(def.value * layer, relic.name, { relic, buff });
+        if (is_add) {
+          context.relic_rune_add.def.addChild(node);
+        } else {
+          context.relic_rune_mul.def.addChild(node);
+        }
       }
       is_invalid = false;
     }

--- a/app/modules/Tool/DamageCalculator/utils.ts
+++ b/app/modules/Tool/DamageCalculator/utils.ts
@@ -82,7 +82,8 @@ export const allowedBlackboardKeyMap: Record<string, string> = {
 };
 
 export const parseBlackboardEntry = (blackboard: BlackboardData, percent?: boolean) =>
-  `${allowedBlackboardKeyMap[blackboard.key] || blackboard.key}: ${percent ? blackboard.value * 100 + "%" : blackboard.value}`;
+  // `${allowedBlackboardKeyMap[blackboard.key] || blackboard.key}: ${percent ? blackboard.value * 100 + "%" : blackboard.value}`;
+  `${allowedBlackboardKeyMap[blackboard.key] || blackboard.key}: ${percent ? Math.round(blackboard.value * 10000) / 100 + "%" : blackboard.value}`;
 
 /**
  * buff.key以global开头的，注册的valueStr
@@ -165,6 +166,7 @@ export const inGameRelicNames = [
   "未叙魔王残片",
   "魔王的祭器",
   "几丁质刺刃",
+  "四方绘料",
 ];
 
 /** 金酒之杯系列 */

--- a/app/stores/damageCalculator/calcConstants.ts
+++ b/app/stores/damageCalculator/calcConstants.ts
@@ -80,7 +80,7 @@ export const initialCalcGameDataState: SlicedCalcGameDataState = {
       zone: "zone_5",
       layer: "layer_5",
       difficulty: 15,
-      tech: "1",
+      tech: "1.2",
       relics: [] as string[],
       wraths: [] as string[],
       coppers: [] as string[],

--- a/app/stores/damageCalculator/slices/gameDataSlice.ts
+++ b/app/stores/damageCalculator/slices/gameDataSlice.ts
@@ -98,7 +98,7 @@ export const createGameDataSlice: SliceCreator<SlicedCalcGameDataState & SlicedC
         zone: "zone_5",
         layer: "layer_5",
         difficulty: 15,
-        tech: "1",
+        tech: "1.2",
         relics: [] as string[],
         wraths: [] as string[],
         coppers: [] as string[],


### PR DESCRIPTION
厉-寒窗志已经正常，可能是改小炒的影响。
测试时发现藏品见衡效果错误，减防减抗应该对敌人但是实际对我方，可能是后端的bug，buff global_buff_normal (4) [{…}, {…}, {…}, {…}]0: {key: 'key', value: 0, valueStr: 'rogue_5_attri_down[unbalance]'}1: {key: 'def', value: -0.3, valueStr: null}2: {key: 'magic_resistance', value: -0.3, valueStr: null}3: {key: 'weak[limit]', value: 10, valueStr: null}length: 4[[Prototype]]: Array(0)
这是接收到的buff数据